### PR TITLE
panel-run-dialog: Use g_spawn_async in both Gtk versions.

### DIFF
--- a/mate-panel/panel-run-dialog.c
+++ b/mate-panel/panel-run-dialog.c
@@ -346,6 +346,15 @@ command_is_executable (const char   *command,
 	return TRUE;
 }
 
+/*
+ * Set the DISPLAY variable, to be use by g_spawn_async.
+ */
+static void
+set_environment (gpointer display)
+{
+  g_setenv ("DISPLAY", display, TRUE);
+}
+
 static void
 dummy_child_watch (GPid         pid,
 		   		   gint         status,
@@ -362,43 +371,32 @@ panel_run_dialog_launch_command (PanelRunDialog *dialog,
 				 const char     *command,
 				 const char     *locale_command)
 {
-#if !GTK_CHECK_VERSION (3, 0, 0)
 	GdkScreen  *screen;
-#endif
 	gboolean    result;
 	GError     *error = NULL;
 	char      **argv;
 	int         argc;
+	char       *display;
 	GPid        pid;
 
 	if (!command_is_executable (locale_command, &argc, &argv))
 		return FALSE;
 
+	screen = gtk_window_get_screen (GTK_WINDOW (dialog->run_dialog));
+
 	if (gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (dialog->terminal_checkbox)))
 		mate_desktop_prepend_terminal_to_vector (&argc, &argv);
 
-#if GTK_CHECK_VERSION (3, 0, 0)
+	display = gdk_screen_make_display_name (screen);
+
 	result = g_spawn_async (NULL, /* working directory */
 				argv,
 				NULL, /* envp */
-				G_SPAWN_SEARCH_PATH,
-				NULL,
-				NULL,
+				G_SPAWN_SEARCH_PATH | G_SPAWN_DO_NOT_REAP_CHILD,
+				set_environment,
+				display,
 				&pid,
 				&error);
-#else
-	screen = gtk_window_get_screen (GTK_WINDOW (dialog->run_dialog));
-
-	result = gdk_spawn_on_screen (screen,
-				      NULL, /* working directory */
-				      argv,
-				      NULL, /* envp */
-				      G_SPAWN_SEARCH_PATH | G_SPAWN_DO_NOT_REAP_CHILD,
-				      NULL, /* child setup func */
-				      NULL, /* user data */
-				      &pid, /* child pid */
-				      &error);
-#endif
 
 	if (!result) {
 		char *primary;


### PR DESCRIPTION
panel-run-dialog: Use g_spawn_async in both Gtk versions.