### PR TITLE
Fix rendering of user backgrounds in gtk3.18+

### DIFF
--- a/mate-panel/panel-background.c
+++ b/mate-panel/panel-background.c
@@ -554,7 +554,11 @@ panel_background_composite (PanelBackground *background)
 		break;
 	}
 
+#if GTK_CHECK_VERSION (3, 0, 0)     /*panel user background fix for gtk3.18+*/
+	background->composited = FALSE; /*this is actually WRONG but fixes rendering of user selected color BG*/
+#else
 	background->composited = TRUE;
+#endif
 
 	panel_background_prepare (background);
 


### PR DESCRIPTION
User set panel backgrounds other than colors with an alpha value fail on restarting the panel using gtk3.18 or 3.19. This makes picture and fully opaque color backgrounds set by the user work again and for some reason does not break transparent color backgrounds either. Tested with gtk3.19.5, should work with gtk3.18 as this bug was exactly the same but needs testing with it. In this case, try to fix the background in cases where the X error handling fix doesn't.