### PR TITLE
Gtk3.19 bugfixes

### DIFF
--- a/applets/clock/clock.c
+++ b/applets/clock/clock.c
@@ -913,6 +913,7 @@ position_calendar_popup (ClockData *cd)
 	gtk_window_get_size (GTK_WINDOW (cd->calendar_popup), &w, &h);
 #if GTK_CHECK_VERSION (3, 0, 0)
 	gtk_widget_get_preferred_size (cd->calendar_popup, &req, NULL);
+	gtk_widget_realize (cd->calendar_popup); /*fix gtk3.20 window position */
 #else
 	gtk_widget_size_request (cd->calendar_popup, &req);
 #endif
@@ -3258,6 +3259,9 @@ display_properties_dialog (ClockData *cd, gboolean start_in_locations_page)
 
         gtk_window_set_screen (GTK_WINDOW (cd->prefs_window),
                                gtk_widget_get_screen (cd->applet));
+#if GTK_CHECK_VERSION (3, 0, 0)
+        gtk_widget_realize (cd->prefs_window); /*fix gtk3.20 window position */
+#endif                               
 	gtk_window_present (GTK_WINDOW (cd->prefs_window));
 
         refresh_click_timeout_time_only (cd);

--- a/mate-panel/panel-properties-dialog.c
+++ b/mate-panel/panel-properties-dialog.c
@@ -911,6 +911,9 @@ panel_properties_dialog_new (PanelToplevel *toplevel,
 
 	gtk_window_set_screen (GTK_WINDOW (dialog->properties_dialog),
 			       gtk_window_get_screen (GTK_WINDOW (toplevel)));
+#if GTK_CHECK_VERSION (3, 0, 0)
+	gtk_widget_realize (dialog->properties_dialog); /*fix gtk3.20 window position */
+#endif			       
 
 	dialog->writability_warn_general = PANEL_GTK_BUILDER_GET (gui, "writability_warn_general");
 	dialog->writability_warn_background = PANEL_GTK_BUILDER_GET (gui, "writability_warn_background");


### PR DESCRIPTION
GTk3: fix calendar window position, panel preferences positions  in gtk3.19/20

This gtk3.19 change looks like it's to stay, these windows now need to call gtk_widget_realize () or they go to the top left side of the screen. Tested in current gtk3.19 and also tested with gtk3.14 to ensure nothing broke with older versions, worked fine in both on my system